### PR TITLE
Example using OpenSSL instead of BoringSSL

### DIFF
--- a/tools/build_openssl/CMakeLists.txt
+++ b/tools/build_openssl/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(external-openssl)
+include(ExternalProject)
+
+message(STATUS "Preparing external project \"openssl\"")
+
+ExternalProject_add(
+    openssl
+    GIT_REPOSITORY https://github.com/akamai/openssl
+    GIT_TAG master-quic-support
+    PREFIX openssl
+    CONFIGURE_COMMAND <SOURCE_DIR>/config $ENV{OPENSSL_PLATFORM} --prefix=${CMAKE_INSTALL_PREFIX} no-shared
+    )


### PR DESCRIPTION
This just adds a CMakeLists.txt to build the Akamai fork of OpenSSL, supposed to support QUIC. It goes on top of https://github.com/litespeedtech/lsquic/pull/169.

To build with BoringSSL (from the LSQUIC root):

```
cmake -DCMAKE_PREFIX_PATH=tools/build_boringssl/install -Bbuild -S.
cmake --build build
```

To build with OpenSSL (from the LSQUIC root):

```
cmake -DCMAKE_PREFIX_PATH=tools/build_openssl/install -Bbuild -S.
cmake --build build
```

To build with the OpenSSL on the system (from the LSQUIC root):

```
cmake -Bbuild -S.
cmake --build build
```